### PR TITLE
feat: save system + input abstraction with gamepad support

### DIFF
--- a/electron/ipc/index.cjs
+++ b/electron/ipc/index.cjs
@@ -1,6 +1,8 @@
 'use strict'
 
-const { ipcMain } = require('electron')
+const { ipcMain, app } = require('electron')
+const path = require('path')
+const fs = require('fs')
 
 /**
  * Register all IPC handlers.
@@ -16,6 +18,28 @@ function registerIpcHandlers(mainWindow) {
 
   ipcMain.handle('window:is-fullscreen', () => {
     return mainWindow.isFullScreen()
+  })
+
+  // --- Data persistence ---
+  ipcMain.handle('data:save', (_, key, data) => {
+    try {
+      const filePath = path.join(app.getPath('userData'), `${key}.json`)
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8')
+      return { success: true }
+    } catch (e) {
+      return { success: false, error: e.message }
+    }
+  })
+
+  ipcMain.handle('data:load', (_, key) => {
+    try {
+      const filePath = path.join(app.getPath('userData'), `${key}.json`)
+      if (!fs.existsSync(filePath)) return { success: true, data: null }
+      const raw = fs.readFileSync(filePath, 'utf8')
+      return { success: true, data: JSON.parse(raw) }
+    } catch (e) {
+      return { success: false, error: e.message }
+    }
   })
 }
 

--- a/electron/ipc/index.cjs
+++ b/electron/ipc/index.cjs
@@ -21,7 +21,12 @@ function registerIpcHandlers(mainWindow) {
   })
 
   // --- Data persistence ---
+  const ALLOWED_SAVE_KEYS = new Set(['settings', 'gameState'])
+
   ipcMain.handle('data:save', (_, key, data) => {
+    if (!ALLOWED_SAVE_KEYS.has(key)) {
+      return { success: false, error: `Unknown save key: ${key}` }
+    }
     try {
       const filePath = path.join(app.getPath('userData'), `${key}.json`)
       fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8')
@@ -32,6 +37,9 @@ function registerIpcHandlers(mainWindow) {
   })
 
   ipcMain.handle('data:load', (_, key) => {
+    if (!ALLOWED_SAVE_KEYS.has(key)) {
+      return { success: false, error: `Unknown save key: ${key}` }
+    }
     try {
       const filePath = path.join(app.getPath('userData'), `${key}.json`)
       if (!fs.existsSync(filePath)) return { success: true, data: null }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -7,6 +7,10 @@ const { registerIpcHandlers } = require('./ipc/index.cjs')
 
 const isDev = process.env.NODE_ENV === 'development'
 
+// Ensure packaged builds use the productName for userData path,
+// not the package.json "name" field (phaser-editor-template-react).
+if (!isDev) app.setName('Equilibrium Protocol')
+
 // ── Crash logging ────────────────────────────────────────────────────────────
 function getLogPath() {
   const logDir = path.join(app.getPath('userData'), 'logs')

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -18,4 +18,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   /** @type {string} 'win32' | 'linux' | 'darwin' */
   platform: process.platform,
+
+  /** @param {string} key @param {Object} data @returns {Promise<{success: boolean, error?: string}>} */
+  saveData: (key, data) => ipcRenderer.invoke('data:save', key, data),
+
+  /** @param {string} key @returns {Promise<{success: boolean, data: Object|null, error?: string}>} */
+  loadData: (key) => ipcRenderer.invoke('data:load', key),
 })

--- a/src/__tests__/InputManager.test.js
+++ b/src/__tests__/InputManager.test.js
@@ -1,0 +1,79 @@
+import { InputManager, INPUT_ACTIONS } from '../game/managers/InputManager'
+
+function makeMockKey(isDown = false) {
+  return { isDown }
+}
+
+function makeMockScene(keyStates = {}) {
+  const defaultState = {
+    [INPUT_ACTIONS.MOVE_UP]: false,
+    [INPUT_ACTIONS.MOVE_DOWN]: false,
+    [INPUT_ACTIONS.MOVE_LEFT]: false,
+    [INPUT_ACTIONS.MOVE_RIGHT]: false,
+    [INPUT_ACTIONS.PAUSE]: false,
+    [INPUT_ACTIONS.DASH]: false,
+    [INPUT_ACTIONS.SHIELD]: false,
+  }
+  const state = { ...defaultState, ...keyStates }
+
+  return {
+    input: {
+      keyboard: {
+        addKey: vi.fn((keyCode) => {
+          const codeMap = {
+            87: INPUT_ACTIONS.MOVE_UP,
+            83: INPUT_ACTIONS.MOVE_DOWN,
+            65: INPUT_ACTIONS.MOVE_LEFT,
+            68: INPUT_ACTIONS.MOVE_RIGHT,
+            32: INPUT_ACTIONS.PAUSE,
+            81: INPUT_ACTIONS.DASH,
+            69: INPUT_ACTIONS.SHIELD,
+          }
+          const action = codeMap[keyCode]
+          return makeMockKey(state[action] || false)
+        }),
+      },
+      gamepad: {
+        once: vi.fn(),
+        getPad: vi.fn().mockReturnValue(null),
+      },
+    },
+  }
+}
+
+vi.mock('phaser', () => ({
+  default: {
+    Input: {
+      Keyboard: {
+        KeyCodes: { W: 87, S: 83, A: 65, D: 68, SPACE: 32, Q: 81, E: 69 },
+        JustDown: vi.fn((key) => key._justDown || false),
+      },
+    },
+  },
+}), { virtual: true })
+
+describe('InputManager', () => {
+  it('reports MOVE_UP as down when W is held', () => {
+    const scene = makeMockScene({ [INPUT_ACTIONS.MOVE_UP]: true })
+    const input = new InputManager(scene)
+    expect(input.isDown(INPUT_ACTIONS.MOVE_UP)).toBe(true)
+  })
+
+  it('reports MOVE_UP as not down when no keys held', () => {
+    const scene = makeMockScene()
+    const input = new InputManager(scene)
+    expect(input.isDown(INPUT_ACTIONS.MOVE_UP)).toBe(false)
+  })
+
+  it('reports false for unknown action', () => {
+    const scene = makeMockScene()
+    const input = new InputManager(scene)
+    expect(input.isDown('NONEXISTENT')).toBe(false)
+  })
+
+  it('does not throw when no gamepad is connected', () => {
+    const scene = makeMockScene()
+    const input = new InputManager(scene)
+    expect(() => input.isDown(INPUT_ACTIONS.MOVE_UP)).not.toThrow()
+  })
+})

--- a/src/__tests__/SaveManager.test.js
+++ b/src/__tests__/SaveManager.test.js
@@ -1,0 +1,59 @@
+import { SaveManager } from '../game/managers/SaveManager'
+
+describe('SaveManager', () => {
+  afterEach(() => {
+    window.localStorage.clear()
+    delete window.electronAPI
+  })
+
+  describe('defaultSettings', () => {
+    it('returns the expected shape', () => {
+      const s = SaveManager.defaultSettings()
+      expect(s).toHaveProperty('musicVolume')
+      expect(s).toHaveProperty('sfxVolume')
+      expect(s).toHaveProperty('fullscreen')
+      expect(typeof s.musicVolume).toBe('number')
+    })
+  })
+
+  describe('loadSettings (localStorage fallback)', () => {
+    it('returns defaults when no saved data exists', async () => {
+      const settings = await SaveManager.loadSettings()
+      expect(settings).toEqual(SaveManager.defaultSettings())
+    })
+
+    it('merges saved data with defaults', async () => {
+      window.localStorage.setItem('eq_settings', JSON.stringify({ musicVolume: 0.08 }))
+      const settings = await SaveManager.loadSettings()
+      expect(settings.musicVolume).toBe(0.08)
+      expect(settings.sfxVolume).toBe(SaveManager.defaultSettings().sfxVolume)
+    })
+  })
+
+  describe('saveSettings (localStorage fallback)', () => {
+    it('writes settings to localStorage', async () => {
+      await SaveManager.saveSettings({ musicVolume: 0.03, sfxVolume: 0.07, fullscreen: true })
+      const raw = window.localStorage.getItem('eq_settings')
+      expect(JSON.parse(raw).musicVolume).toBe(0.03)
+    })
+  })
+
+  describe('loadSettings (Electron path)', () => {
+    it('calls electronAPI.loadData with the settings key', async () => {
+      window.electronAPI = {
+        loadData: vi.fn().mockResolvedValue({ success: true, data: { musicVolume: 0.1 } })
+      }
+      const settings = await SaveManager.loadSettings()
+      expect(window.electronAPI.loadData).toHaveBeenCalledWith('settings')
+      expect(settings.musicVolume).toBe(0.1)
+    })
+
+    it('returns defaults when electronAPI returns success:false', async () => {
+      window.electronAPI = {
+        loadData: vi.fn().mockResolvedValue({ success: false, error: 'disk error' })
+      }
+      const settings = await SaveManager.loadSettings()
+      expect(settings).toEqual(SaveManager.defaultSettings())
+    })
+  })
+})

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,16 +1,35 @@
 import '@testing-library/jest-dom'
 
-// Node.js 25 ships a built-in `localStorage` on globalThis that is broken
-// without the --localstorage-file flag. Replace it with an in-memory
-// implementation so localStorage-dependent tests work under jsdom.
-if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.setItem !== 'function') {
-  const store = {}
-  globalThis.localStorage = {
-    setItem(key, value) { store[key] = String(value) },
-    getItem(key) { return key in store ? store[key] : null },
-    removeItem(key) { delete store[key] },
-    clear() { Object.keys(store).forEach(k => delete store[k]) },
-    get length() { return Object.keys(store).length },
-    key(i) { return Object.keys(store)[i] ?? null },
+// Node 25+ ships a built-in `localStorage` that is broken without --localstorage-file.
+// Replace it with a reliable in-memory implementation whenever the native one is
+// missing, incomplete, or throws at runtime (probe with an actual set/get round-trip).
+const store = {}
+const inMemoryLocalStorage = {
+  setItem(key, value) { store[key] = String(value) },
+  getItem(key) { return key in store ? store[key] : null },
+  removeItem(key) { delete store[key] },
+  clear() { Object.keys(store).forEach(k => delete store[k]) },
+  get length() { return Object.keys(store).length },
+  key(i) { return Object.keys(store)[i] ?? null },
+}
+
+let shouldReplace =
+  typeof globalThis.localStorage === 'undefined' ||
+  typeof globalThis.localStorage.setItem !== 'function' ||
+  typeof globalThis.localStorage.getItem !== 'function' ||
+  typeof globalThis.localStorage.removeItem !== 'function'
+
+if (!shouldReplace) {
+  const probeKey = '__test_localStorage_probe__'
+  try {
+    globalThis.localStorage.setItem(probeKey, 'ok')
+    if (globalThis.localStorage.getItem(probeKey) !== 'ok') shouldReplace = true
+    globalThis.localStorage.removeItem(probeKey)
+  } catch {
+    shouldReplace = true
   }
+}
+
+if (shouldReplace) {
+  globalThis.localStorage = inMemoryLocalStorage
 }

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom'
+
+// Node.js 25 ships a built-in `localStorage` on globalThis that is broken
+// without the --localstorage-file flag. Replace it with an in-memory
+// implementation so localStorage-dependent tests work under jsdom.
+if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.setItem !== 'function') {
+  const store = {}
+  globalThis.localStorage = {
+    setItem(key, value) { store[key] = String(value) },
+    getItem(key) { return key in store ? store[key] : null },
+    removeItem(key) { delete store[key] },
+    clear() { Object.keys(store).forEach(k => delete store[k]) },
+    get length() { return Object.keys(store).length },
+    key(i) { return Object.keys(store)[i] ?? null },
+  }
+}

--- a/src/game/entities/Player.js
+++ b/src/game/entities/Player.js
@@ -1060,8 +1060,8 @@ export class Player {
     }
 
     updateMovement() {
-        // Get keyboard references from scene
-        const keys = this.scene.wasd;
+        // Get input manager from scene
+        const input = this.scene.inputManager;
 
         // Reset velocity for this frame
         this.velX = 0;
@@ -1071,16 +1071,16 @@ export class Player {
         const moveSpeed = 300; // Use a higher value for better responsiveness
 
         // Apply direct velocity based on keys
-        if (keys.up.isDown) {
+        if (input.isDown('MOVE_UP')) {
             this.velY = -moveSpeed;
         }
-        if (keys.down.isDown) {
+        if (input.isDown('MOVE_DOWN')) {
             this.velY = moveSpeed;
         }
-        if (keys.left.isDown) {
+        if (input.isDown('MOVE_LEFT')) {
             this.velX = -moveSpeed;
         }
-        if (keys.right.isDown) {
+        if (input.isDown('MOVE_RIGHT')) {
             this.velX = moveSpeed;
         }
 

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -32,6 +32,10 @@ const config = {
         deltaHistory: 10,     // Number of frames to calculate average
         panicMax: 60         // FPS threshold to reset delta history if exceeded
     },
+    // Enable gamepad input
+    input: {
+        gamepad: true
+    },
     // Enable physics
     physics: {
         default: 'arcade',

--- a/src/game/managers/InputManager.js
+++ b/src/game/managers/InputManager.js
@@ -38,6 +38,10 @@ export class InputManager {
       [INPUT_ACTIONS.SHIELD]:     scene.input.keyboard.addKey(K.E),
     }
 
+    // Track previous gamepad button state for rising-edge (justDown) detection
+    /** @type {Record<string, boolean>} */
+    this._prevGamepadState = {}
+
     scene.input.gamepad.once('connected', (pad) => {
       console.log('[InputManager] Gamepad connected:', pad.id)
     })
@@ -54,7 +58,7 @@ export class InputManager {
   }
 
   /**
-   * Returns true only on the first frame the action is pressed.
+   * Returns true only on the first frame the action is pressed (rising edge).
    * @param {string} action - One of INPUT_ACTIONS values
    * @returns {boolean}
    */
@@ -63,10 +67,11 @@ export class InputManager {
       ? Phaser.Input.Keyboard.JustDown(this.keys[action])
       : false
     if (keyJustDown) return true
-    return this._isGamepadActionDown(action)
+    return this._isGamepadActionJustDown(action)
   }
 
   /**
+   * Returns true while the gamepad action is held.
    * @private
    */
   _isGamepadActionDown(action) {
@@ -91,5 +96,17 @@ export class InputManager {
       default:
         return false
     }
+  }
+
+  /**
+   * Returns true only on the rising edge of a gamepad action (first frame pressed).
+   * Reads current state, compares to previous frame, then stores current as previous.
+   * @private
+   */
+  _isGamepadActionJustDown(action) {
+    const current = this._isGamepadActionDown(action)
+    const previous = this._prevGamepadState[action] ?? false
+    this._prevGamepadState[action] = current
+    return current && !previous
   }
 }

--- a/src/game/managers/InputManager.js
+++ b/src/game/managers/InputManager.js
@@ -1,0 +1,95 @@
+import Phaser from 'phaser'
+
+/**
+ * Named input actions. Use these constants when calling isDown() or justDown().
+ */
+export const INPUT_ACTIONS = {
+  MOVE_UP:    'MOVE_UP',
+  MOVE_DOWN:  'MOVE_DOWN',
+  MOVE_LEFT:  'MOVE_LEFT',
+  MOVE_RIGHT: 'MOVE_RIGHT',
+  PAUSE:      'PAUSE',
+  DASH:       'DASH',
+  SHIELD:     'SHIELD',
+}
+
+const GAMEPAD_DEADZONE = 0.5
+
+/**
+ * Abstracts keyboard and gamepad input behind named actions.
+ * Created once per WaveGame scene. Player reads from scene.inputManager.
+ */
+export class InputManager {
+  /**
+   * @param {Phaser.Scene} scene
+   */
+  constructor(scene) {
+    this.scene = scene
+    const K = Phaser.Input.Keyboard.KeyCodes
+
+    /** @type {Record<string, Phaser.Input.Keyboard.Key>} */
+    this.keys = {
+      [INPUT_ACTIONS.MOVE_UP]:    scene.input.keyboard.addKey(K.W),
+      [INPUT_ACTIONS.MOVE_DOWN]:  scene.input.keyboard.addKey(K.S),
+      [INPUT_ACTIONS.MOVE_LEFT]:  scene.input.keyboard.addKey(K.A),
+      [INPUT_ACTIONS.MOVE_RIGHT]: scene.input.keyboard.addKey(K.D),
+      [INPUT_ACTIONS.PAUSE]:      scene.input.keyboard.addKey(K.SPACE),
+      [INPUT_ACTIONS.DASH]:       scene.input.keyboard.addKey(K.Q),
+      [INPUT_ACTIONS.SHIELD]:     scene.input.keyboard.addKey(K.E),
+    }
+
+    scene.input.gamepad.once('connected', (pad) => {
+      console.log('[InputManager] Gamepad connected:', pad.id)
+    })
+  }
+
+  /**
+   * Returns true while the action is held (keyboard OR gamepad).
+   * @param {string} action - One of INPUT_ACTIONS values
+   * @returns {boolean}
+   */
+  isDown(action) {
+    if (this.keys[action]?.isDown) return true
+    return this._isGamepadActionDown(action)
+  }
+
+  /**
+   * Returns true only on the first frame the action is pressed.
+   * @param {string} action - One of INPUT_ACTIONS values
+   * @returns {boolean}
+   */
+  justDown(action) {
+    const keyJustDown = this.keys[action]
+      ? Phaser.Input.Keyboard.JustDown(this.keys[action])
+      : false
+    if (keyJustDown) return true
+    return this._isGamepadActionDown(action)
+  }
+
+  /**
+   * @private
+   */
+  _isGamepadActionDown(action) {
+    const pad = this.scene.input.gamepad?.getPad(0)
+    if (!pad) return false
+
+    switch (action) {
+      case INPUT_ACTIONS.MOVE_UP:
+        return pad.up || pad.leftStick.y < -GAMEPAD_DEADZONE
+      case INPUT_ACTIONS.MOVE_DOWN:
+        return pad.down || pad.leftStick.y > GAMEPAD_DEADZONE
+      case INPUT_ACTIONS.MOVE_LEFT:
+        return pad.left || pad.leftStick.x < -GAMEPAD_DEADZONE
+      case INPUT_ACTIONS.MOVE_RIGHT:
+        return pad.right || pad.leftStick.x > GAMEPAD_DEADZONE
+      case INPUT_ACTIONS.PAUSE:
+        return pad.isButtonDown(9)  // Start / Menu
+      case INPUT_ACTIONS.DASH:
+        return pad.isButtonDown(0)  // A / Cross
+      case INPUT_ACTIONS.SHIELD:
+        return pad.isButtonDown(1)  // B / Circle
+      default:
+        return false
+    }
+  }
+}

--- a/src/game/managers/SaveManager.js
+++ b/src/game/managers/SaveManager.js
@@ -1,0 +1,78 @@
+/**
+ * @typedef {Object} SettingsData
+ * @property {number} musicVolume   - 0 to 0.1
+ * @property {number} sfxVolume     - 0 to 0.1
+ * @property {boolean} fullscreen
+ */
+
+/**
+ * @typedef {Object} GameStateData
+ * @property {number} highestWave
+ * @property {number} totalKills
+ */
+
+/**
+ * Persistent save/settings storage.
+ * Uses Electron IPC on desktop, localStorage on web.
+ * All methods are static and async.
+ */
+export class SaveManager {
+  /** @returns {SettingsData} */
+  static defaultSettings() {
+    return { musicVolume: 0.05, sfxVolume: 0.07, fullscreen: false }
+  }
+
+  /** @returns {GameStateData} */
+  static defaultGameState() {
+    return { highestWave: 0, totalKills: 0 }
+  }
+
+  /** @returns {Promise<SettingsData>} */
+  static async loadSettings() {
+    return SaveManager._load('settings', SaveManager.defaultSettings())
+  }
+
+  /** @param {SettingsData} settings @returns {Promise<void>} */
+  static async saveSettings(settings) {
+    return SaveManager._save('settings', settings)
+  }
+
+  /** @returns {Promise<GameStateData>} */
+  static async loadGameState() {
+    return SaveManager._load('gameState', SaveManager.defaultGameState())
+  }
+
+  /** @param {GameStateData} state @returns {Promise<void>} */
+  static async saveGameState(state) {
+    return SaveManager._save('gameState', state)
+  }
+
+  static async _load(key, defaults) {
+    try {
+      if (window.electronAPI?.loadData) {
+        const result = await window.electronAPI.loadData(key)
+        if (result.success && result.data) {
+          return { ...defaults, ...result.data }
+        }
+      } else {
+        const raw = window.localStorage.getItem(`eq_${key}`)
+        if (raw) return { ...defaults, ...JSON.parse(raw) }
+      }
+    } catch (e) {
+      console.warn(`[SaveManager] Load failed for "${key}", using defaults:`, e.message)
+    }
+    return { ...defaults }
+  }
+
+  static async _save(key, data) {
+    try {
+      if (window.electronAPI?.saveData) {
+        await window.electronAPI.saveData(key, data)
+      } else {
+        window.localStorage.setItem(`eq_${key}`, JSON.stringify(data))
+      }
+    } catch (e) {
+      console.warn(`[SaveManager] Save failed for "${key}":`, e.message)
+    }
+  }
+}

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -99,6 +99,12 @@ export class MainMenu extends Scene
                     this.soundManager.setMusicVolume(value);
                     this.soundManager.setEffectsVolume(value);
                 }
+                // Persist settings — fire and forget
+                SaveManager.saveSettings({
+                    musicVolume: value,
+                    sfxVolume: value,
+                    fullscreen: this.scale.isFullscreen,
+                });
             }
         });
     }

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -116,11 +116,13 @@ export class MainMenu extends Scene
         // Create sound manager
         this.soundManager = new SoundManager(this);
 
-        // Apply saved volume settings
+        // Apply saved volume settings via setters so clamping logic is applied
         const savedSettings = this.registry.get('savedSettings')
         if (savedSettings) {
-            this.soundManager.musicVolume = savedSettings.musicVolume
-            this.soundManager.effectsVolume = savedSettings.sfxVolume
+            const music = Number(savedSettings.musicVolume)
+            const sfx = Number(savedSettings.sfxVolume)
+            if (Number.isFinite(music)) this.soundManager.setMusicVolume(Math.max(0, Math.min(0.1, music)))
+            if (Number.isFinite(sfx)) this.soundManager.setEffectsVolume(Math.max(0, Math.min(0.1, sfx)))
         }
 
         // Initialize menu music

--- a/src/game/scenes/MainMenu.js
+++ b/src/game/scenes/MainMenu.js
@@ -1,6 +1,7 @@
 import { EventBus } from '../EventBus';
 import { Scene } from 'phaser';
 import { SoundManager } from '../managers/SoundManager';
+import { SaveManager } from '../managers/SaveManager';
 import { DEPTHS } from '../constants';
 import { VolumeSlider } from '../ui/VolumeSlider';
 import { ButtonSoundHelper } from '../utils/ButtonSoundHelper';
@@ -82,7 +83,7 @@ export class MainMenu extends Scene
             fillColor: 0x39C66B, // Match the green color of the start button
             knobColor: 0xffffff,
             knobRadius: 8,
-            initialValue: this.soundManager ? this.soundManager.musicVolume : 0.5,
+            initialValue: this.soundManager ? (this.soundManager.musicVolume / 0.1) : 0.5,
             depth: 100,
             label: 'Volume',
             labelStyle: {
@@ -108,6 +109,13 @@ export class MainMenu extends Scene
     setupSoundManager() {
         // Create sound manager
         this.soundManager = new SoundManager(this);
+
+        // Apply saved volume settings
+        const savedSettings = this.registry.get('savedSettings')
+        if (savedSettings) {
+            this.soundManager.musicVolume = savedSettings.musicVolume
+            this.soundManager.effectsVolume = savedSettings.sfxVolume
+        }
 
         // Initialize menu music
         this.soundManager.initBackgroundMusic('menu_music', {

--- a/src/game/scenes/Preloader.js
+++ b/src/game/scenes/Preloader.js
@@ -1,5 +1,6 @@
 import { EventBus } from '../EventBus';
 import { Scene } from 'phaser';
+import { SaveManager } from '../managers/SaveManager';
 
 export class Preloader extends Scene
 {
@@ -155,11 +156,20 @@ export class Preloader extends Scene
         this.load.tilemapTiledJSON('darkcavemap', 'assets/maps/darkcavenet.json');
     }
 
-    create ()
+    async create ()
     {
         // Double check if particle_texture was loaded, if not create a fallback
         if (!this.textures.exists('particle_texture')) {
             this.createFallbackParticleTexture();
+        }
+
+        // Load saved settings and store in Phaser's cross-scene registry
+        try {
+            const settings = await SaveManager.loadSettings()
+            this.registry.set('savedSettings', settings)
+        } catch (e) {
+            console.warn('[Preloader] Failed to load settings, using defaults:', e)
+            this.registry.set('savedSettings', SaveManager.defaultSettings())
         }
 
         EventBus.emit('preloader-complete', this);

--- a/src/game/scenes/WaveGame.jsx
+++ b/src/game/scenes/WaveGame.jsx
@@ -23,6 +23,7 @@ import { HealthRegenerationSystem } from '../systems/HealthRegenerationSystem';
 import { AnimationManager } from '../managers/AnimationManager';
 import { DEPTHS, CHAOS } from '../constants';
 import { KillTimerManager } from '../managers/KillTimerManager';
+import { SaveManager } from '../managers/SaveManager';
 
 /**
  * WaveGame scene
@@ -1114,6 +1115,11 @@ export class WaveGame extends Scene {
             console.debug('Victory! All waves completed.');
         }
 
+        this.saveSessionStats(
+            this.waveManager ? this.waveManager.maxWaves : 20,
+            this.killCount || 0
+        )
+
         // Show victory UI
         this.uiManager.showVictoryUI();
 
@@ -1847,6 +1853,24 @@ export class WaveGame extends Scene {
     }
 
     /**
+     * Save end-of-session stats (wave reached, kills).
+     * Accumulates total kills across sessions.
+     * @param {number} waveReached
+     * @param {number} sessionKills
+     */
+    async saveSessionStats(waveReached, sessionKills) {
+        try {
+            const current = await SaveManager.loadGameState()
+            await SaveManager.saveGameState({
+                highestWave: Math.max(current.highestWave, waveReached),
+                totalKills: current.totalKills + sessionKills,
+            })
+        } catch (e) {
+            console.warn('[WaveGame] Failed to save session stats:', e)
+        }
+    }
+
+    /**
      * Handle player death
      * Called when player health reaches 0
      */
@@ -1856,6 +1880,11 @@ export class WaveGame extends Scene {
 
         // Set game over state
         this.isGameOver = true;
+
+        this.saveSessionStats(
+            this.waveManager ? this.waveManager.currentWave : 0,
+            this.killCount || 0
+        )
 
         // Stop any active waves
         if (this.waveManager) {

--- a/src/game/scenes/WaveGame.jsx
+++ b/src/game/scenes/WaveGame.jsx
@@ -24,6 +24,7 @@ import { AnimationManager } from '../managers/AnimationManager';
 import { DEPTHS, CHAOS } from '../constants';
 import { KillTimerManager } from '../managers/KillTimerManager';
 import { SaveManager } from '../managers/SaveManager';
+import { InputManager } from '../managers/InputManager';
 
 /**
  * WaveGame scene
@@ -905,22 +906,8 @@ export class WaveGame extends Scene {
             this.isMouseDown = false;
         });
 
-        // Set up WASD keys
-        this.wasd = {
-            up: this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.W),
-            down: this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.S),
-            left: this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.A),
-            right: this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D)
-        };
-
-        // Set up spacebar for pause
-        this.pauseKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
-
-        // Set up Q key for dash ability
-        this.dashKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Q);
-
-        // Set up E key for shield ability
-        this.shieldKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.E);
+        // Unified input manager (keyboard + gamepad)
+        this.inputManager = new InputManager(this);
 
 
         // Set up volume control keys (9 for volume down, 0 for volume up)
@@ -1258,7 +1245,7 @@ export class WaveGame extends Scene {
 
     update(time, delta) {
         // Handle pause state
-        if (Phaser.Input.Keyboard.JustDown(this.pauseKey)) {
+        if (this.inputManager.justDown('PAUSE')) {
             this.togglePause();
         }
 
@@ -1335,7 +1322,7 @@ export class WaveGame extends Scene {
         }
 
         // Check for dash ability activation (Q key)
-        if (Phaser.Input.Keyboard.JustDown(this.dashKey)) {
+        if (this.inputManager.justDown('DASH')) {
             if (this.player.hasDash) {
                 const dashActivated = this.player.activateDash();
 
@@ -1370,7 +1357,7 @@ export class WaveGame extends Scene {
         }
 
         // Check for shield ability activation (E key)
-        if (Phaser.Input.Keyboard.JustDown(this.shieldKey)) {
+        if (this.inputManager.justDown('SHIELD')) {
             if (this.player.hasShield) {
                 const shieldActivated = this.player.activateShield();
 


### PR DESCRIPTION
## Summary

- Adds persistent save/settings storage via Electron IPC on desktop, localStorage fallback on web
- Adds `InputManager` abstracting keyboard and gamepad input behind named actions
- Volume settings now persist across sessions; game stats (highest wave, total kills) saved on death/victory
- Steam Deck / Xbox / PS controllers work out of the box via Phaser gamepad API
- Control scheme wiring is in place — button mapping can be tuned later

## New files
- `src/game/managers/SaveManager.js` — static async class, IPC + localStorage fallback
- `src/game/managers/InputManager.js` — named actions (MOVE_UP/DOWN/LEFT/RIGHT, PAUSE, DASH, SHIELD) mapped to keyboard + gamepad
- `src/__tests__/SaveManager.test.js` — 6 tests
- `src/__tests__/InputManager.test.js` — 4 tests

## Modified files
- `electron/ipc/index.cjs` — added `data:save` and `data:load` handlers
- `electron/preload.cjs` — exposed `saveData` and `loadData` on `window.electronAPI`
- `electron/main.cjs` — explicitly sets app name in packaged builds so userData resolves to `~/.config/Equilibrium Protocol/` not the package name
- `src/game/main.js` — enabled `input.gamepad: true` in Phaser config
- `src/game/scenes/Preloader.js` — loads settings async, stores in Phaser registry
- `src/game/scenes/MainMenu.js` — applies saved volume on load, persists on slider change
- `src/game/scenes/WaveGame.jsx` — uses InputManager, saves stats on death/victory
- `src/game/entities/Player.js` — reads movement from `scene.inputManager` instead of `scene.wasd`
- `src/__tests__/setup.js` — fixed Node 25 localStorage compatibility in test environment

## Test plan
- [x] `npm test` — 16/16 tests passing (5 test files)
- [x] `npm run dev:electron` — WASD, Space, Q, E all work; volume persists across restarts
- [x] `npm run build:linux` — AppImage saves to `~/.config/Equilibrium Protocol/`; gamepad moves player

🤖 Generated with [Claude Code](https://claude.com/claude-code)